### PR TITLE
Use movement type for radius accessor

### DIFF
--- a/examples/140_radius.html
+++ b/examples/140_radius.html
@@ -2,38 +2,25 @@
 <html>
 
 <head>
-<title>Cindy JS Example</title>
+<title>Programmatically setting the radius</title>
 <meta charset="UTF-8">
 <script type="text/javascript" src="../build/js/Cindy.js"></script>
-<script id="csinit" type="text/x-cindyscript">
-
-// Initialization code, executed once up front.
-
-</script>
-<script id="csdraw" type="text/x-cindyscript">
-
-C.radius = 5;
-// Drawing code, executed whenever the canvas gets redrawn.
-
-</script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = createCindy({
   ports: [{id: "CSCanvas"}],
   scripts: "cs*",
   language: "en",
-  defaultAppearance: {
-    // See GeoBasics.js for possible attributes.
-  },
+  defaultAppearance: {},
   geometry: [
-    {name:"A", type:"Free", pos:[0,0]},
-    {name:"C", type:"CircleMr", args:["A"], radius:0.5},
-    // For allowed types, see GeoOps.js.
-    // For allowed properties, see csinit in GeoBasics.js.
-  ] // End of geometry array.
+    {name:"A", type:"Free", pos:[-3,0]},
+    {name:"B", type:"Free", pos:[5,0]},
+    {name:"C", type:"CircleMr", args:["A"], radius:5},
+    {name:"D", type:"CircleMr", args:["B"], radius:4},
+    {name:"Es", type:"IntersectCirCir", args:["C", "D"]},
+    {name:"E", type:"SelectP", args:["Es"], pos:[5,1]},
+  ]
 });
-
-// Remove all comments after adjusting this template for your use case.
 
 </script>
 </head>
@@ -41,6 +28,10 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 <body style="font-family:Arial;">
   <canvas id="CSCanvas" width="500" height="500"
           style="border:2px solid black"></canvas>
+  <p>
+    <button onclick="cdy.evokeCS('C.radius=3')">r=3</button>
+    <button onclick="cdy.evokeCS('C.radius=5')">r=5</button>
+  </p>
 </body>
 
 </html>

--- a/src/js/libcs/Accessors.js
+++ b/src/js/libcs/Accessors.js
@@ -231,12 +231,8 @@ Accessor.setField = function(geo, field, value) {
         movepointscr(geo, dir, "dir");
     }
     if (geo.kind === "C") {
-        if (field === "radius" && geo.matrix.usage === "Circle" && value.ctype === "number") {
-
-            stateContinueFromHere();
-            tracingFailed = false;
-            traceMover(geo, null, "script", value);
-            stateContinueFromHere();
+        if (field === "radius" && geo.type === "CircleMr" && value.ctype === "number") {
+            movepointscr(geo, value, "radius");
         }
     }
     if (geo.behavior) {

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -649,7 +649,8 @@ geoOps.CircleMr.isMovable = true;
 geoOps.CircleMr.initialize = function(el) {
     putStateComplexNumber(CSNumber.real(el.radius));
 };
-geoOps.CircleMr.getParamForInput = function(el, pos) {
+geoOps.CircleMr.getParamForInput = function(el, pos, type) {
+    if (type === "radius") return pos;
     var m = csgeo.csnames[(el.args[0])].homog;
     m = List.normalizeZ(m);
     pos = List.normalizeZ(pos);


### PR DESCRIPTION
This is (in my opinion) an improvement CindyJS#293, using the existing movement type instead of introducing a new argument. It also expands the example so that the tracing nature of the change can be observed.
