### PR TITLE
Simplify segments and fix PointOnSegment

### DIFF
--- a/examples/111_Moebius_Arc.html
+++ b/examples/111_Moebius_Arc.html
@@ -24,11 +24,11 @@ var cdy = CindyJS({
     {name:"AA", type:"Free", pos:[-6,1]},
     {name:"BB", type:"Free", pos:[0,-4]},
     {name:"CC", type:"Free", pos:[-2,-4]},
-    {name:"Arc", type:"ArcBy3", args:["AA", "BB", "CC"], color: [0,1,0]},
+    {name:"Arc", type:"ArcBy3", args:["AA", "BB", "CC"], color:[0,0.75,0], size:2},
 	
 
     {name:"Tr0", type:"TrMoebius", args:["A1","B1","A2","B2","A3","B3"]},
-    {name:"ArcTr", type:"TrMoebiusArc", args:["Tr0","Arc"], color:[0, 1, 1]},
+    {name:"ArcTr", type:"TrMoebiusArc", args:["Tr0","Arc"], color:[0, 0, 1], size:2},
 
   ]
 });

--- a/examples/62_ProjTransform.html
+++ b/examples/62_ProjTransform.html
@@ -5,33 +5,6 @@
 <title>Cindy JS</title>
 <link rel="stylesheet" href="../css/cindy.css">
 <script type="text/javascript" src="../build/js/Cindy.js"></script>
-<script id="csdraw" type="text/x-cindyscript">
-n=10;
-
-// draw a bilinear grid in the original quadrilateral
-drawall(apply(0..n,i,(
-  a = (1/n*(i*A1.xy + (n-i)*A2.xy)) :> 1;
-  b = (1/n*(i*A4.xy + (n-i)*A3.xy)) :> 1;
-  [a,b]
-)));
-drawall(apply(0..n,i,(
-  a = (1/n*(i*A1.xy + (n-i)*A4.xy)) :> 1;
-  b = (1/n*(i*A2.xy + (n-i)*A3.xy)) :> 1;
-  [a,b]
-)));
-
-// draw its image under the projective transformation
-drawall(apply(0..n,i,(
-  a = (1/n*(i*A1.xy + (n-i)*A2.xy)) :> 1;
-  b = (1/n*(i*A4.xy + (n-i)*A3.xy)) :> 1;
-  [a,b]*transpose(Tr0.matrix)
-)));
-drawall(apply(0..n,i,(
-  a = (1/n*(i*A1.xy + (n-i)*A4.xy)) :> 1;
-  b = (1/n*(i*A2.xy + (n-i)*A3.xy)) :> 1;
-  [a,b]*transpose(Tr0.matrix)
-)));
-</script>
 <script type="text/javascript">
 var gslp = [
   {name:"A1", type:"Free", pos:[0,0], color:[255, 0, 0]},
@@ -45,7 +18,24 @@ var gslp = [
   {name:"Tr0", type:"TrProjection", args:["A1","B1","A2","B2","A3","B3","A4","B4"]},
   {name:"P", type:"Free", pos:[0.5,0.5], color:[255, 0, 255]},
   {name:"Q", type:"TransformP", args:["Tr0","P"], color:[0, 255, 255]},
+  {name:"S1", type:"Segment", args:["A1","A2"], color:[0,0,1]},
+  {name:"S2", type:"Segment", args:["A2","A3"], color:[0,0,1]},
+  {name:"S3", type:"Segment", args:["A3","A4"], color:[0,0,1]},
+  {name:"S4", type:"Segment", args:["A4","A1"], color:[0,0,1]},
 ];
+var n = 10;
+for (var i = 0; i <= n; ++i) {
+  gslp.push(
+    {name:"X1_"+i, type:"PointOnSegment", args:["S1"], pos:[i/n, 0], visible:false},
+    {name:"X2_"+i, type:"PointOnSegment", args:["S3"], pos:[i/n, 1], visible:false},
+    {name:"Y1_"+i, type:"PointOnSegment", args:["S4"], pos:[0, i/n], visible:false},
+    {name:"Y2_"+i, type:"PointOnSegment", args:["S2"], pos:[1, i/n], visible:false},
+    {name:"X_"+i, type:"Segment", args:["X1_"+i, "X2_"+i]},
+    {name:"Y_"+i, type:"Segment", args:["Y1_"+i, "Y2_"+i]},
+    {name:"tX_"+i, type:"TransformSegment", args:["Tr0", "X_"+i]},
+    {name:"tY_"+i, type:"TransformSegment", args:["Tr0", "Y_"+i]});
+}
+gslp.push({name:"Z", type:"PointOnSegment", args:["tY_"+(n>>1)], pos:[2.75,0.5], color:[1,1,0]});
 CindyJS({
   canvasname:"CSCanvas",
   scripts:"cs*",

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -246,9 +246,7 @@ eval_helper.drawarc = function(args, modifs, df) {
         if (Bmiddle) {
             Render2D.drawsegcore(ptA, ptC);
         } else { // nasty case -- B not in the middle -- we have 2 ray to infinity
-            var sflip = dAB > dBC ? 1 : -1;
-            Render2D.drawRaySegment(a, b,
-                c, sflip);
+            Render2D.drawRaySegment(a, c);
         }
     }
 

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -619,17 +619,16 @@ Render2D.drawline = function(homog) {
     }
 };
 
-// draws a segment consisting of 2 rays
-Render2D.drawRaySegment = function(A, B, C, sflip) {
+// draws a segment through infinity, consisting of 2 rays
+Render2D.drawRaySegment = function(A, B) {
     var ptA = eval_helper.extractPoint(A);
     var ptB = eval_helper.extractPoint(B);
-    var ptC = eval_helper.extractPoint(C);
-    if (!ptA.ok || !ptB.ok || !ptC.ok) {
+    if (!ptA.ok || !ptB.ok) {
         return;
     }
 
-    var dx = sflip * (ptA.x - ptB.x);
-    var dy = sflip * (ptA.y - ptB.y);
+    var dx = ptA.x - ptB.x;
+    var dy = ptA.y - ptB.y;
     var norm = Math.sqrt(dx * dx + dy * dy);
 
     // get points outside canvas (at "infinity")
@@ -643,9 +642,9 @@ Render2D.drawRaySegment = function(A, B, C, sflip) {
         x: ptA.x + dx,
         y: ptA.y + dy
     });
-    Render2D.drawsegcore(ptC, {
-        x: ptC.x - dx,
-        y: ptC.y - dy
+    Render2D.drawsegcore(ptB, {
+        x: ptB.x - dx,
+        y: ptB.y - dy
     });
 };
 

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -94,22 +94,21 @@ geoOps.Segment.signature = ["P", "P"];
 geoOps.Segment.updatePosition = function(el) {
     var el1 = csgeo.csnames[(el.args[0])];
     var el2 = csgeo.csnames[(el.args[1])];
-    el.homog = List.cross(el1.homog, el2.homog);
-    el.homog = List.normalizeMax(el.homog);
-    el.homog = General.withUsage(el.homog, "Line");
-    el.startpos = el1.homog;
-    el.endpos = el2.homog;
-    el.farpoint = List.cross(el.homog, List.linfty);
-    el.midpoint = geoOps._helper.midpoint(el1.homog, el2.homog);
+    geoOps.Segment.setSegmentPos(el,
+        List.cross(el1.homog, el2.homog),
+        List.scalmult(el2.homog.value[2], el1.homog),
+        List.scalmult(el1.homog.value[2], el2.homog)
+    );
 };
-
-geoOps._helper.crSegment = function(seg, p) {
-    var sh = seg.homog;
-    var tt = List.turnIntoCSList([sh.value[0], sh.value[1], CSNumber.zero]);
-    var far = List.turnIntoCSList([sh.value[1], CSNumber.neg(sh.value[0]), CSNumber.zero]);
-    var cr = List.crossratio3(
-        far, seg.startpos, seg.endpos, p, tt);
-    return cr;
+geoOps.Segment.setSegmentPos = function(el, line, start, end) {
+    line = List.normalizeMax(line);
+    el.homog = General.withUsage(line, "Line");
+    var startend = List.turnIntoCSList([start, end]);
+    startend = List.normalizeMax(startend); // Normalize together!
+    el.startpos = startend.value[0];
+    el.endpos = startend.value[1];
+    // So  midpoint = startpos + endpos
+    // and farpoint = startpos - endpos
 };
 
 
@@ -598,8 +597,9 @@ geoOps.PointOnSegment.getParamForInput = function(el, pos) {
     var seg = csgeo.csnames[el.args[0]];
     var line = seg.homog;
     var tt = List.turnIntoCSList([line.value[0], line.value[1], CSNumber.zero]);
+    var farpoint = List.sub(seg.startpos, seg.endpos);
     var cr = List.crossratio3(
-        seg.farpoint, seg.startpos, seg.endpos, pos, tt);
+        farpoint, seg.startpos, seg.endpos, pos, tt);
     if (cr.value.real < 0)
         cr = CSNumber.complex(0, cr.value.imag);
     if (cr.value.real > 1)
@@ -616,11 +616,8 @@ geoOps.PointOnSegment.updatePosition = function(el) {
     var param = getStateComplexNumber();
     putStateComplexNumber(param); // copy parameter
     var seg = csgeo.csnames[el.args[0]];
-    // TODO: Handle case where seg is the result of a projective transform,
-    // where seg.farpoint would not have z==0. Can't happen yet.
-    var start = List.scalmult(seg.endpos.value[2], seg.startpos);
-    var end = List.scalmult(seg.startpos.value[2], seg.endpos);
-    // now they have the same z coordinate, so their difference is far
+    var start = seg.startpos;
+    var end = seg.endpos;
     var far = List.sub(end, start);
     var homog = List.add(start, List.scalmult(param, far));
     homog = List.normalizeMax(homog);
@@ -1883,8 +1880,8 @@ geoOps.TrMoebiusS.updatePosition = function(el) {
     var s = csgeo.csnames[(el.args[1])];
 
     var a1 = s.startpos;
-    var a2 = s.midpoint;
     var a3 = s.endpos;
+    var a2 = List.add(a1, a3);
 
     var b1 = geoOps._helper.TrMoebiusP(a1, tr);
     var b2 = geoOps._helper.TrMoebiusP(a2, tr);
@@ -2363,17 +2360,11 @@ geoOps.TransformS.signature = ["Tr", "S"];
 geoOps.TransformS.updatePosition = function(el) {
     var tr = csgeo.csnames[(el.args[0])];
     var s = csgeo.csnames[(el.args[1])];
-
-    var MVmax = function(M, p) {
-        return List.normalizeMax(List.productMV(M, p));
-    };
-
-    el.homog = MVmax(tr.dualMatrix, s.homog);
-    el.homog = General.withUsage(el.homog, "Line");
-    el.startpos = MVmax(tr.matrix, s.startpos);
-    el.endpos = MVmax(tr.matrix, s.endpos);
-    el.farpoint = MVmax(tr.matrix, s.farpoint);
-    el.midpoint = MVmax(tr.matrix, s.midpoint);
+    geoOps.Segment.setSegmentPos(el,
+        List.productMV(tr.dualMatrix, s.homog),
+        List.productMV(tr.matrix, s.startpos),
+        List.productMV(tr.matrix, s.endpos)
+    );
 };
 
 geoOps.TransformPolygon = {};

--- a/src/js/libgeo/GeoRender.js
+++ b/src/js/libgeo/GeoRender.js
@@ -86,16 +86,15 @@ function drawgeoline(el) {
             arrowshape: el.arrowshape,
             arrowsides: el.arrowsides,
         };
-        var cr = geoOps._helper.crSegment(el, el.midpoint).value.real;
-        if (cr > 0 && cr < 1) { // normal case 
+        var zz = CSNumber.mult(el.startpos.value[2],
+            CSNumber.conjugate(el.endpos.value[2]));
+        if (zz.value.real >= 0) { // finite segment
             evaluator.draw$2(
                 [el.startpos, el.endpos], modifs);
             return;
-        } else { // transformed segment with 2 rays
-            var flip = cr < 0 ? -1 : 1;
+        } else { // transformed segment through infinity, consisting of 2 rays
             Render2D.handleModifs(modifs, Render2D.lineModifs);
-            Render2D.drawRaySegment(el.startpos, el.midpoint,
-                el.endpos, flip);
+            Render2D.drawRaySegment(el.startpos, el.endpos);
             return;
         }
     }


### PR DESCRIPTION
_This is intended as a contribution towards CindyJS#453._

This simplifies segments in the following way: instead of storing three or more points to establish a projective basis, we only store two, but we make sure that we maintain a given relation between the representatives of these. For a regular segment, the sum of these two endpoint vectors will be the midpoint, while the difference will be the farpoint.  For projectively transformed segments these relations hold for the images of the midpoint resp. farpoint.

Besides the reduced number of properties, this is also essentially the format which is most appropriate for `PointOnSegment` computations, since it allows turning a parameter `t` into `start + t*(end - start)`, which the previous implementation only did correctly for untransformed segments.

Another benefit is that it is now easier to figure out whether a given line segment with real coordinates passes through infinity: If the _z_ coordinates of the endpoints have the same sign, the segment is finite, else it is infinite.  This is far cheaper than a cross ratio computation would be. (If coordinates are complex, one of the _z_ coordinates would need to be conjugated, and although that shouldn't happen when drawing, the code does include that conjugation in case such a snippet should get copied elsehwere.)

This commit also edits examples to demonstrate and test new features.  
- In particular the `62_ProjTransform.html` example was changed from a scripted version (which cannot easily draw segments through infinity) to a GSLP-based version which now gets rendered correctly.  Furthermore a point was added on one of the projectively transformed lines, which maintains its position relative to the grid even under projective transformations, demonstrating the soundness of the new `PointOnLine` computation.
- The example `15_ProjectiveGrid.html` suffers from the same incorrect rendering of line segments, but since it also demonstrates the use of `map$8`, it was left as is in order to preserve the example for that function.
- `111_Moebius_Arc.html` was modified to make the arcs more visible, particularly in cases where they coincide with the grid.  This is needed to ensure proper rendering of the segment-through-infinity case there.

When evaluating this proposal, it is important to keep the `PointOnSegment` fix in mind. Any suggestion for a different implementation (based on three or four points as a basis with no fixed representative relationship) should demonstrate how to handle that operation in an elegant fashion.

The reduced number of parameters to `drawRaySegment` could conceivably lead to trouble in cases where the two endpoints are very close together, since then it would be harder to derive the direction of the line from these. On the other hand, the code now works even if the midpoint is at infinity; a situation where it is impossible to extract affine coordinates from such a point. A solution which fixes the former without reintroducing the latter would be very welcome.
